### PR TITLE
salting and hashing passwords added

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -3,6 +3,9 @@ const pword = "p9M9f2fmKNe7Thgb";
 const cluster = "messengerdb.y9swx";
 const dbname = "MouseChatDB";
 
+const bcrypt = require("bcryptjs") // adding bcrypt into the database, from sildes
+
+
 const uri = `mongodb+srv://${uname}:${pword}@${cluster}.mongodb.net/${dbname}?retryWrites=true&w=majority&appName=MessengerDB`;
 
 const mongoose = require('mongoose');

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -9,7 +9,7 @@ const UserSchema = new mongoose.Schema({
     password: {
         type: String,
         required: true,
-        maxLength: 25
+        maxLength: 60 //changed to account for bcrypt hash, so user is entered into database 
     },
     cheese: {
         type: String,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.3",
         "cookie-parser": "^1.4.7",
         "express": "^4.21.1",
@@ -148,6 +149,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.3",
     "cookie-parser": "^1.4.7",
     "express": "^4.21.1",


### PR DESCRIPTION
passwords are now salted and hashed using bcrpyt. Hash is stored instead of password in database and is checked against the hash of the login attempt password. initial hashing was added to the signup function in controller.js, password field was modified to 60 character limit to account of hash size in model.js. checking was added to login function in controller, needed to define a new findUser function that only returned username in order to get the password form the database separately.